### PR TITLE
Fix width

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ go:
   - master
 
 before_script:
+  - go get -d
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Requires [git](https://git-scm.com/download/win) to clone and [Go](https://golan
 ```bash
 $ git clone https://github.com/muhammadmuzzammil1998/catsay.git
 $ cd catsay
+$ go get -d
 $ go build
 ```
 

--- a/app.go
+++ b/app.go
@@ -31,7 +31,8 @@ import (
 	"io"
 	"os"
 	"strings"
-	"unicode/utf8"
+
+	"github.com/mattn/go-runewidth"
 )
 
 //Defining a main cat
@@ -87,9 +88,9 @@ func readLines(reader *bufio.Reader) []string {
 func getWidth(message []string) int {
 	ret := cat.MinLen
 	for _, l := range message {
-		len := utf8.RuneCountInString(l)
-		if len > ret {
-			ret = len
+		width := runewidth.StringWidth(l)
+		if width > ret {
+			ret = width
 		}
 	}
 	return ret
@@ -131,7 +132,8 @@ func removeTabs(message []string) []string {
 func formatMessage(message []string, width int) []string {
 	var ret []string
 	for _, l := range message {
-		ret = append(ret, l+strings.Repeat(" ", width-utf8.RuneCountInString(l)))
+		w := runewidth.StringWidth(l)
+		ret = append(ret, l+strings.Repeat(" ", width-w))
 	}
 	return ret
 }

--- a/app_test.go
+++ b/app_test.go
@@ -39,6 +39,7 @@ func TestReadLines(t *testing.T) {
 		t.Fatalf("Couldn't parse bufio.Reader")
 	}
 }
+
 func TestGetWidth(t *testing.T) {
 	setup()
 	r := getWidth(message)
@@ -46,12 +47,14 @@ func TestGetWidth(t *testing.T) {
 		t.Fatalf("Expected to be greater or equal to 9 but got %d", r)
 	}
 }
+
 func TestRemoveTabs(t *testing.T) {
 	r := removeTabs(message)
 	if r[4] != "this    one    has    tabs!" {
 		t.Fatalf("Tabs were not replaced with spaces")
 	}
 }
+
 func TestCreateMessage(t *testing.T) {
 	setup()
 	data := removeTabs(message)
@@ -68,6 +71,7 @@ func TestCreateMessage(t *testing.T) {
 		t.Fatalf("Expected\n%s\nbut got\n%s", e, r)
 	}
 }
+
 func TestFormatMessage(t *testing.T) {
 	setup()
 	data := removeTabs(message)
@@ -79,5 +83,17 @@ func TestFormatMessage(t *testing.T) {
 	}
 	if eLen != rLen {
 		t.Fatalf("Length of each line should be equal. Expected %d but got %d", eLen, rLen)
+	}
+}
+
+func TestMultiByteString(t *testing.T) {
+	setup()
+	data := removeTabs(buildMessage("こんにちわ世界"))
+	got := createMessage(data, getWidth(data))
+	var want = ` ________________
+< こんにちわ世界 >
+ ----------------`
+	if got != want {
+		t.Fatalf("Expected\n%s\nbut got\n%s", want, got)
 	}
 }


### PR DESCRIPTION
# Description

Current implementation use utf8.RuneCountInString to calculate width of strings. But this is not right. In multi-byte strings, there are many characters which take 2 cells.

![image](https://user-images.githubusercontent.com/10111/55520782-c32d2e00-56b8-11e9-8fd1-dfc2f59d4629.png)


Fixes # (issue)

Use github.com/mattn/go-runewidth to calculate correct widths.

![image](https://user-images.githubusercontent.com/10111/55520803-d809c180-56b8-11e9-839f-79d4d731d86e.png)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TestMultiByteString to make sure fixes with multi-byte strings

**Test Configuration**:

* Not requires or instructions for this test 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
